### PR TITLE
feat: Improve generateCacheKey to handle complex objects

### DIFF
--- a/frontend/src/utils/cache.ts
+++ b/frontend/src/utils/cache.ts
@@ -1,4 +1,26 @@
 /**
+ * Recursively sort object keys to ensure consistent JSON.stringify output.
+ * @param obj - The object to sort.
+ * @returns A new object with sorted keys.
+ */
+function sortObjectKeys(obj: any): any {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(sortObjectKeys);
+  }
+
+  const sortedKeys = Object.keys(obj).sort();
+  const sortedObj: Record<string, any> = {};
+  for (const key of sortedKeys) {
+    sortedObj[key] = sortObjectKeys(obj[key]);
+  }
+  return sortedObj;
+}
+
+/**
  * Cache utilities
  */
 
@@ -7,7 +29,7 @@
  * @param prefix - A prefix for the cache key.
  * @param params - An object of parameters to include in the key.
  * @returns A consistent cache key string.
- * 
+ *
  * Note: This function uses JSON.stringify to serialize parameter values.
  * For complex objects or arrays, ensure that the stringified representation
  * is consistent and deterministic. Keys are sorted to ensure consistent
@@ -16,7 +38,10 @@
 export function generateCacheKey(prefix: string, params: Record<string, any>): string {
   const sortedKeys = Object.keys(params).sort();
   const paramString = sortedKeys
-    .map(key => `${key}=${JSON.stringify(params[key])}`)
+    .map(key => {
+      const sortedValue = sortObjectKeys(params[key]);
+      return `${key}=${JSON.stringify(sortedValue)}`;
+    })
     .join('&');
   return `${prefix}:${paramString}`;
 }


### PR DESCRIPTION
This PR improves the generateCacheKey function to handle complex objects and arrays by recursively sorting object keys before stringifying. This addresses issue #72.