### PR TITLE
fix: setup_performance_middlewareの呼び出し欠如を修正 (#150)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from sqlalchemy import text
 
 from .stock_storage.database import init_db, close_database, check_database_health, get_database_stats, get_session_scope
 from .middleware.error_handler import setup_error_handlers
+from .middleware.performance import setup_performance_middleware
 from .utils.logging import setup_logging
 from .utils.cache import get_cache_stats
 from .services.stock_service import cleanup_stock_service
@@ -62,12 +63,8 @@ app = FastAPI(
     openapi_url=OPENAPI_URL,
 )
 
-# Add GZip middleware for response compression (performance optimization)
-app.add_middleware(
-    GZipMiddleware, 
-    minimum_size=PerformanceThresholds.COMPRESSION_MIN_SIZE, 
-    compresslevel=PerformanceThresholds.COMPRESSION_LEVEL
-)
+# Performance middleware setup (includes GZip compression and other optimizations)
+setup_performance_middleware(app)
 
 # Add CORS middleware
 app.add_middleware(


### PR DESCRIPTION
## Summary
- main.pyでsetup_performance_middlewareをインポート
- 重複したGZipMiddleware設定を統一されたsetup_performance_middleware()呼び出しに置換
- パフォーマンスミドルウェア（リクエストID、レスポンス時間測定、キャッシュ制御、圧縮等）が正常に動作することを確認

## Test plan
- [x] パフォーマンスヘッダー（x-request-id、x-response-time）がAPIレスポンスに含まれることを確認
- [x] APIサーバーログにリクエストID、レスポンス時間、詳細なリクエスト情報が記録されることを確認
- [x] /stocks/7203エンドポイントで200レスポンス時にパフォーマンスミドルウェアが正常動作することを確認

Closes #150

🤖 Generated with [Claude Code](https://claude.ai/code)