### PR TITLE
FIX: ミドルウェア適用順序と冗長性を修正

### DIFF
--- a/src/middleware/performance.py
+++ b/src/middleware/performance.py
@@ -211,17 +211,16 @@ def setup_performance_middleware(app: FastAPI):
     """
     Set up all performance optimization middleware.
     """
+    # Add custom performance middleware
+    # Order is important: CacheControlMiddleware -> GZipMiddleware -> PerformanceMetricsMiddleware
+    app.add_middleware(CacheControlMiddleware)
     # Add GZip compression (built-in FastAPI middleware)
     app.add_middleware(
         GZipMiddleware,
         minimum_size=PerformanceThresholds.COMPRESSION_MIN_SIZE,
         compresslevel=PerformanceThresholds.COMPRESSION_LEVEL  # Balance between compression ratio and CPU usage
     )
-    
-    # Add custom performance middleware
     app.add_middleware(PerformanceMetricsMiddleware)
-    app.add_middleware(ResponseCompressionMiddleware)
-    app.add_middleware(CacheControlMiddleware)
 
 
 # Utility functions for manual performance optimization


### PR DESCRIPTION
このPRは、setup_performance_middleware関数内のミドルウェア適用順序を修正し、不要なResponseCompressionMiddlewareを削除します。キャッシュ機能が正しく動作するようにし、パフォーマンス計測が正確になるようにします。Fixes #168.