### PR TITLE
feat(api): OpenAPIサーバーURLの環境変数対応 (API_PUBLIC_URL 他)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,21 @@ DATABASE_MAX_OVERFLOW=10
 DEBUG=false
 LOG_LEVEL=INFO
 
+# Middleware Configuration
+# Enable or disable specific middleware components.
+# Set to 'true' to enable, 'false' to disable.
+MIDDLEWARE_CORS_ENABLED=true
+MIDDLEWARE_ERROR_HANDLING_ENABLED=true
+MIDDLEWARE_PERFORMANCE_ENABLED=true
+
+# OpenAPI / Public URLs
+# Publicly accessible API base URL (e.g., behind reverse proxy / production)
+# Example: https://api.stockvision.example.com
+API_PUBLIC_URL=
+# Additional server URLs to include in the OpenAPI servers list (comma-separated)
+# Example: https://staging.api.stockvision.example.com, https://dev.api.stockvision.example.com
+API_ADDITIONAL_SERVER_URLS=
+
 # Example configurations for different environments:
 
 ## Development with mock data (fast, no external API calls):

--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ curl -X DELETE http://localhost:8000/watchlist/1
 - Swagger UI: http://localhost:8000/docs
 - ReDoc: http://localhost:8000/redoc
 
+本番環境などで公開URLが異なる場合は、以下の環境変数でOpenAPIの`servers`を設定できます。
+
+- `API_PUBLIC_URL`: 公開APIのベースURL（例: `https://api.stockvision.example.com`）
+- `API_ADDITIONAL_SERVER_URLS`: 追加サーバーURL（カンマ区切り）
+
+`.env` 例:
+
+```
+API_PUBLIC_URL=https://api.stockvision.example.com
+API_ADDITIONAL_SERVER_URLS=https://staging.api.stockvision.example.com, https://dev.api.stockvision.example.com
+```
+
 ## テスト実行
 
 ```bash

--- a/src/constants/api.py
+++ b/src/constants/api.py
@@ -2,6 +2,8 @@
 API related constants for the StockVision application.
 """
 
+import os
+
 # API Endpoints
 API_PREFIX = "/api"
 
@@ -37,9 +39,14 @@ FRONTEND_DEV_PORT = 3000
 FRONTEND_PROD_PORT = 8080
 
 # CORS origins
+# 環境変数から本番用オリジンを読み込み
+PROD_ORIGINS_STR = os.getenv("PROD_CORS_ORIGINS", "")
+PROD_ORIGINS = [origin.strip() for origin in PROD_ORIGINS_STR.split(",") if origin.strip()]
+
 CORS_ORIGINS = [
     f"http://{DEVELOPMENT_HOST}:{FRONTEND_DEV_PORT}",
-    f"http://{DEVELOPMENT_HOST}:{FRONTEND_PROD_PORT}"
+    f"http://{DEVELOPMENT_HOST}:{FRONTEND_PROD_PORT}",
+    *PROD_ORIGINS,  # 本番環境オリジンを追加
 ]
 
 # OpenAPI documentation


### PR DESCRIPTION
OpenAPIのserversを環境別に安全に生成するよう改善しました。

- 新環境変数:
  - API_PUBLIC_URL: 本番・公開用ベースURL
  - API_ADDITIONAL_SERVER_URLS: 追加サーバーURL（カンマ区切り）
- 既定動作:
  - 変数未設定時は http://localhost:8000 をDevelopment serverとして設定
- README/.env.example を更新

関連: #200