### PR TITLE
sec(cors): 本番環境CORS設定の厳格化（PROD_CORS_ORIGINSとDEBUGに基づく分岐）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,10 @@ MIDDLEWARE_CORS_ENABLED=true
 MIDDLEWARE_ERROR_HANDLING_ENABLED=true
 MIDDLEWARE_PERFORMANCE_ENABLED=true
 
+# CORS / Allowed origins (production)
+# 本番環境で許可するオリジンをカンマ区切りで指定（例: https://stockvision.example.com, https://app.stockvision.jp）
+PROD_CORS_ORIGINS=
+
 # OpenAPI / Public URLs
 # Publicly accessible API base URL (e.g., behind reverse proxy / production)
 # Example: https://api.stockvision.example.com

--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,21 @@ DATABASE_MAX_OVERFLOW=10
 DEBUG=false
 LOG_LEVEL=INFO
 
+# Middleware Configuration
+# Enable or disable specific middleware components.
+# Set to 'true' to enable, 'false' to disable.
+MIDDLEWARE_CORS_ENABLED=true
+MIDDLEWARE_ERROR_HANDLING_ENABLED=true
+MIDDLEWARE_PERFORMANCE_ENABLED=true
+
+# OpenAPI / Public URLs
+# Publicly accessible API base URL (e.g., behind reverse proxy / production)
+# Example: https://api.stockvision.example.com
+API_PUBLIC_URL=
+# Additional server URLs to include in the OpenAPI servers list (comma-separated)
+# Example: https://staging.api.stockvision.example.com, https://dev.api.stockvision.example.com
+API_ADDITIONAL_SERVER_URLS=
+
 # Example configurations for different environments:
 
 ## Development with mock data (fast, no external API calls):

--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ curl -X DELETE http://localhost:8000/watchlist/1
 - Swagger UI: http://localhost:8000/docs
 - ReDoc: http://localhost:8000/redoc
 
+本番環境などで公開URLが異なる場合は、以下の環境変数でOpenAPIの`servers`を設定できます。
+
+- `API_PUBLIC_URL`: 公開APIのベースURL（例: `https://api.stockvision.example.com`）
+- `API_ADDITIONAL_SERVER_URLS`: 追加サーバーURL（カンマ区切り）
+
+`.env` 例:
+
+```
+API_PUBLIC_URL=https://api.stockvision.example.com
+API_ADDITIONAL_SERVER_URLS=https://staging.api.stockvision.example.com, https://dev.api.stockvision.example.com
+```
+
 ## テスト実行
 
 ```bash

--- a/src/constants/__init__.py
+++ b/src/constants/__init__.py
@@ -36,6 +36,8 @@ __all__ = [
     "FRONTEND_DEV_PORT",
     "FRONTEND_PROD_PORT",
     "CORS_ORIGINS",
+    "DEV_CORS_ORIGINS",
+    "PROD_ORIGINS",
     "DOCS_URL",
     "REDOC_URL", 
     "OPENAPI_URL",

--- a/src/constants/api.py
+++ b/src/constants/api.py
@@ -39,15 +39,18 @@ FRONTEND_DEV_PORT = 3000
 FRONTEND_PROD_PORT = 8080
 
 # CORS origins
-# 環境変数から本番用オリジンを読み込み
+# 環境変数から本番用オリジンを読み込み（カンマ区切り）
 PROD_ORIGINS_STR = os.getenv("PROD_CORS_ORIGINS", "")
 PROD_ORIGINS = [origin.strip() for origin in PROD_ORIGINS_STR.split(",") if origin.strip()]
 
-CORS_ORIGINS = [
+# 開発時のデフォルト許可オリジン
+DEV_CORS_ORIGINS = [
     f"http://{DEVELOPMENT_HOST}:{FRONTEND_DEV_PORT}",
     f"http://{DEVELOPMENT_HOST}:{FRONTEND_PROD_PORT}",
-    *PROD_ORIGINS,  # 本番環境オリジンを追加
 ]
+
+# 後方互換: 既存参照向け（本番・開発を問わず網羅的に含む）
+CORS_ORIGINS = [*DEV_CORS_ORIGINS, *PROD_ORIGINS]
 
 # OpenAPI documentation
 DOCS_URL = "/docs"

--- a/src/constants/api.py
+++ b/src/constants/api.py
@@ -2,6 +2,8 @@
 API related constants for the StockVision application.
 """
 
+import os
+
 # API Endpoints
 API_PREFIX = "/api"
 
@@ -37,9 +39,14 @@ FRONTEND_DEV_PORT = 3000
 FRONTEND_PROD_PORT = 8080
 
 # CORS origins
+# 環境変数から本番用オリジンを読み込み
+PROD_ORIGINS_STR = os.getenv("PROD_CORS_ORIGINS", "")
+PROD_ORIGINS = [origin.strip() for origin in PROD_ORIGINS_STR.split(",") if origin.strip()]
+
 CORS_ORIGINS = [
     f"http://{DEVELOPMENT_HOST}:{FRONTEND_DEV_PORT}",
-    f"http://{DEVELOPMENT_HOST}:{FRONTEND_PROD_PORT}"
+    f"http://{DEVELOPMENT_HOST}:{FRONTEND_PROD_PORT}",
+    *PROD_ORIGINS,  # 本番環境オリジンを追加
 ]
 
 # OpenAPI documentation

--- a/tests/unit/test_cors_config.py
+++ b/tests/unit/test_cors_config.py
@@ -1,0 +1,56 @@
+import os
+from importlib import reload, import_module
+
+
+def test_compute_allowed_cors_origins_dev(monkeypatch):
+    # Arrange
+    os.environ["PROD_CORS_ORIGINS"] = "https://prod.example.com"
+
+    # Re-import after env change
+    # Reload constants (reflect env change) then main
+    reload(import_module('src.constants.api'))
+    reload(import_module('src.constants'))
+    from src import main as main_mod
+    reload(main_mod)
+
+    # Act
+    origins = main_mod.compute_allowed_cors_origins(debug=True)
+
+    # Assert
+    assert "http://localhost:3000" in origins
+    assert "http://localhost:8080" in origins
+    assert "https://prod.example.com" in origins
+
+
+def test_compute_allowed_cors_origins_prod_only(monkeypatch):
+    # Arrange
+    os.environ["PROD_CORS_ORIGINS"] = "https://prod.example.com, https://www.stockvision.jp"
+
+    reload(import_module('src.constants.api'))
+    reload(import_module('src.constants'))
+    from src import main as main_mod
+    reload(main_mod)
+
+    # Act
+    origins = main_mod.compute_allowed_cors_origins(debug=False)
+
+    # Assert
+    assert "http://localhost:3000" not in origins
+    assert "https://prod.example.com" in origins
+    assert "https://www.stockvision.jp" in origins
+
+
+def test_compute_allowed_cors_origins_filters_invalid(monkeypatch):
+    # Arrange
+    os.environ["PROD_CORS_ORIGINS"] = "*, http://, not-a-url, https://ok.example.com"
+
+    reload(import_module('src.constants.api'))
+    reload(import_module('src.constants'))
+    from src import main as main_mod
+    reload(main_mod)
+
+    # Act
+    origins = main_mod.compute_allowed_cors_origins(debug=False)
+
+    # Assert
+    assert origins == ["https://ok.example.com"]


### PR DESCRIPTION
## 目的
本番環境で開発用オリジン（localhost等）が許可される問題を解消し、環境変数ベースで厳格に制御できるようにしました。関連: #199

## 変更点
- src/constants/api.py
  - DEV_CORS_ORIGINS と PROD_ORIGINS を明示化
  - 互換のため CORS_ORIGINS は維持（未使用）
- src/main.py
  - compute_allowed_cors_origins(debug: bool) を導入
    - debug=True: 開発+本番オリジン許可
    - debug=False: 本番オリジンのみ
  - オリジンのバリデーションを追加（http/httpsかつホスト必須、*不可）
- .env.example
  - PROD_CORS_ORIGINS を追記
- 	ests/unit/test_cors_config.py
  - ユニットテストを追加（dev/prod/無効値の3ケース）
- README.md
  - OpenAPIサーバーURLの説明を追記済（前PR #202）

## 動作
- DEBUG=true（開発）: http://localhost:3000, http://localhost:8080 + PROD_CORS_ORIGINS
- DEBUG=false（本番）: PROD_CORS_ORIGINS のみ
- 無効値は除外（*, スキーム不明、ホスト無しなど）

## テスト
- pytest tests/unit/test_cors_config.py で3ケース通過

ご確認お願いします。