### PR TITLE
feat(backend): Prometheus metrics endpoint + req fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,12 +244,15 @@ npm run dev
 USE_REAL_YAHOO_API=false
 DATABASE_URL=sqlite:///data/stock_tracking.db
 LOG_LEVEL=INFO
+ENABLE_METRICS=false
 ```
 
 #### フロントエンド (.env)
 ```
 VITE_API_BASE_URL=http://localhost:8000
 ```
+
+メトリクスを有効化する場合は `ENABLE_METRICS=true` を設定し、`/metrics` エンドポイントから Prometheus 形式で取得できます。
 
 ## 📊 パフォーマンス
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,4 +48,8 @@ marshmallow==3.20.1
 # Background task processing (optional)
 celery==5.3.4
 
-# Monitoring and metrics (optional)\nprometheus-client==0.19.0\n\n# Documentation generation\nmkdocs-material==9.5.31 
+# Monitoring and metrics (optional)
+prometheus-client==0.19.0
+
+# Documentation generation
+mkdocs-material==9.5.31

--- a/src/api/stocks.py
+++ b/src/api/stocks.py
@@ -49,7 +49,11 @@ def get_db():
            })
 @cache_stock_data(ttl=300.0)  # 5分間キャッシュ
 async def get_stock_info(
-    stock_code: str = Path(..., pattern=r"^[0-9]{4}$", example="7203"),
+    stock_code: str = Path(
+        ...,
+        pattern=r"^[0-9]{4}$",
+        examples={"default": {"summary": "Example", "value": "7203"}},
+    ),
     use_real_data: Optional[bool] = Query(
         None, 
         description="Use real Yahoo Finance API (true) or mock data (false). Defaults to environment setting."
@@ -114,7 +118,11 @@ async def get_stock_info(
            })
 @cache_current_price()  # 1分間キャッシュ
 async def get_current_price(
-    stock_code: str = Path(..., pattern=r"^[0-9]{4}$", example="7203"),
+    stock_code: str = Path(
+        ...,
+        pattern=r"^[0-9]{4}$",
+        examples={"default": {"summary": "Example", "value": "7203"}},
+    ),
     use_real_data: Optional[bool] = Query(
         None, 
         description="Use real Yahoo Finance API (true) or mock data (false). Defaults to environment setting."

--- a/src/middleware/metrics.py
+++ b/src/middleware/metrics.py
@@ -1,0 +1,114 @@
+"""
+Prometheus metrics middleware and endpoint for FastAPI.
+
+Enable by setting environment variable `ENABLE_METRICS=true`.
+Exposes `/metrics` endpoint in Prometheus text format and records
+HTTP request counts and latency histograms.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Callable
+
+from fastapi import FastAPI, Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+
+try:
+    from prometheus_client import Counter, Histogram, CONTENT_TYPE_LATEST, generate_latest
+except Exception:  # pragma: no cover - optional dependency path
+    Counter = None  # type: ignore
+    Histogram = None  # type: ignore
+    CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"  # type: ignore
+    def generate_latest():  # type: ignore
+        return b""  # minimal fallback
+
+
+REQUEST_COUNT = None
+REQUEST_LATENCY = None
+
+
+def _init_metrics():
+    global REQUEST_COUNT, REQUEST_LATENCY
+    if REQUEST_COUNT is not None:
+        return
+    if Counter is None or Histogram is None:
+        return
+
+    REQUEST_COUNT = Counter(
+        "http_requests_total",
+        "Total HTTP requests",
+        labelnames=("method", "path", "status"),
+    )
+    REQUEST_LATENCY = Histogram(
+        "http_request_duration_seconds",
+        "HTTP request latency in seconds",
+        labelnames=("method", "path", "status"),
+        buckets=(
+            0.005,
+            0.01,
+            0.025,
+            0.05,
+            0.1,
+            0.25,
+            0.5,
+            1.0,
+            2.5,
+            5.0,
+        ),
+    )
+
+
+def _get_path_template(request: Request) -> str:
+    # Use route path template if available to avoid high-cardinality labels
+    try:
+        route = request.scope.get("route")
+        if route and hasattr(route, "path"):
+            return route.path or request.url.path
+    except Exception:
+        pass
+    return request.url.path
+
+
+class PrometheusMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        if REQUEST_COUNT is None or REQUEST_LATENCY is None:
+            return await call_next(request)
+
+        start = time.perf_counter()
+        response: Response = await call_next(request)
+        duration = time.perf_counter() - start
+
+        path_tmpl = _get_path_template(request)
+        method = request.method
+        status = str(response.status_code)
+
+        try:
+            REQUEST_COUNT.labels(method=method, path=path_tmpl, status=status).inc()
+            REQUEST_LATENCY.labels(method=method, path=path_tmpl, status=status).observe(duration)
+        except Exception:
+            # Metrics must never break request handling
+            pass
+
+        return response
+
+
+def setup_metrics(app: FastAPI) -> None:
+    """Setup Prometheus metrics if ENABLE_METRICS=true."""
+    enabled = os.getenv("ENABLE_METRICS", "false").lower() == "true"
+    if not enabled:
+        return
+
+    _init_metrics()
+
+    # Add middleware for request metrics
+    app.add_middleware(PrometheusMiddleware)
+
+    # Expose /metrics endpoint
+    @app.get("/metrics", include_in_schema=False)
+    async def metrics_endpoint() -> Response:
+        content = generate_latest()
+        return Response(content=content, media_type=CONTENT_TYPE_LATEST)
+

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,26 @@
+import os
+from importlib import reload
+
+
+def test_metrics_endpoint_enabled(monkeypatch):
+    # Enable metrics via env
+    os.environ["ENABLE_METRICS"] = "true"
+
+    # Reload app to pick env
+    from src import main as main_mod
+    reload(main_mod)
+
+    from fastapi.testclient import TestClient
+
+    client = TestClient(main_mod.app)
+
+    # Trigger at least one request so counters increment
+    client.get("/")
+
+    res = client.get("/metrics")
+    assert res.status_code == 200
+    text = res.text
+    # Should include our metric family names when enabled
+    assert "http_requests_total" in text
+    assert "http_request_duration_seconds" in text
+


### PR DESCRIPTION
This PR adds optional Prometheus metrics instrumentation and fixes a minor packaging issue.

Changes
- Add /metrics endpoint and request metrics middleware (env-gated via ENABLE_METRICS=true)
- Record http_requests_total and http_request_duration_seconds with method/path/status labels
- Fix equirements.txt stray literal \n newlines that break pip install
- Replace deprecated Pydantic xample= usage with xamples= in path params
- Update README with ENABLE_METRICS env var

Notes
- Metrics are optional and won’t affect runtime if disabled
- Configured middleware at import time to avoid Starlette restriction during lifespan