### PR TITLE
docs: Observability pack (Prometheus/Grafana/Alerts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,3 +271,8 @@ VITE_API_BASE_URL=http://localhost:8000
 ## 📝 ライセンス
 
 このプロジェクトはMITライセンスの下で公開されています。
+# 📈 オブザーバビリティ
+
+- Prometheusスクレイプ例: `docs/observability/prometheus-scrape.md`
+- Grafanaダッシュボード: `docs/observability/grafana-dashboard.json`
+- Alertmanagerルール例: `docs/observability/alerts.yml`

--- a/docs/observability/alerts.yml
+++ b/docs/observability/alerts.yml
@@ -1,0 +1,41 @@
+groups:
+  - name: stockvision-backend
+    interval: 30s
+    rules:
+      - alert: HighHttpErrorRate
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m]))
+            / clamp_min(sum(rate(http_requests_total[5m])), 1) > 0.05
+        for: 10m
+        labels:
+          severity: page
+        annotations:
+          summary: "High HTTP 5xx error rate (>5% for 10m)"
+
+      - alert: SlowHttpLatencyP90
+        expr: |
+          histogram_quantile(0.9, sum(rate(http_request_duration_seconds_bucket[5m])) by (le)) > 0.8
+        for: 10m
+        labels:
+          severity: warn
+        annotations:
+          summary: "HTTP p90 latency > 800ms"
+
+      - alert: ExternalApiErrors
+        expr: |
+          sum(rate(external_api_requests_total{status=~"error|invalid"}[5m])) > 0
+        for: 15m
+        labels:
+          severity: warn
+        annotations:
+          summary: "External API errors observed for 15m"
+
+      - alert: DbSlowQueries
+        expr: |
+          histogram_quantile(0.9, sum(rate(db_query_duration_seconds_bucket[5m])) by (le)) > 0.05
+        for: 15m
+        labels:
+          severity: warn
+        annotations:
+          summary: "DB p90 query latency > 50ms for 15m"
+

--- a/docs/observability/grafana-dashboard.json
+++ b/docs/observability/grafana-dashboard.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": 38,
+  "title": "StockVision Backend Overview",
+  "timezone": "browser",
+  "editable": true,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "HTTP RPS",
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[1m]))",
+          "legendFormat": "rps"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "HTTP Latency (p50/p90/p99)",
+      "gridPos": {"h": 8, "w": 12, "x": 6, "y": 0},
+      "targets": [
+        {"expr": "histogram_quantile(0.5, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p50"},
+        {"expr": "histogram_quantile(0.9, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p90"},
+        {"expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p99"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "DB Query Duration",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "targets": [
+        {"expr": "histogram_quantile(0.9, sum(rate(db_query_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p90"}
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "External API Error Rate",
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 8},
+      "targets": [
+        {"expr": "sum(rate(external_api_requests_total{status=\"error\"}[5m])) / clamp_min(sum(rate(external_api_requests_total[5m])), 1)", "legendFormat": "error%"}
+      ],
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "orientation": "horizontal"},
+      "fieldConfig": {"defaults": {"unit": "percentunit"}, "overrides": []}
+    }
+  ],
+  "templating": {"list": []},
+  "version": 1
+}
+

--- a/docs/observability/prometheus-scrape.md
+++ b/docs/observability/prometheus-scrape.md
@@ -1,0 +1,36 @@
+# Prometheus Scrape Config (Sample)
+
+Add a scrape job for the backend `/metrics` endpoint. Protect with `METRICS_BASIC_AUTH` and/or `METRICS_ALLOW_CIDRS` as needed.
+
+```yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "stockvision-backend"
+    metrics_path: /metrics
+    scheme: http
+    static_configs:
+      - targets: ["stockvision-backend:8000"]
+        labels:
+          service: stockvision
+          env: production
+    # If Basic Auth is enabled
+    basic_auth:
+      username: "user"
+      password: "pass"
+    # If behind a proxy that sets X-Forwarded-For, keep headers
+    # relabel_configs:
+    #   - action: replace
+    #     source_labels: [__address__]
+    #     target_label: instance
+```
+
+Exposed metrics include:
+- `http_requests_total{method,path,status}`
+- `http_request_duration_seconds{method,path,status}`
+- `db_ping_duration_seconds`
+- `db_query_duration_seconds`
+- `external_api_requests_total{service,operation,status}`
+- `external_api_duration_seconds{service,operation,status}`
+


### PR DESCRIPTION
Adds Prometheus scrape sample, Grafana dashboard JSON, Alertmanager rules, and README link.